### PR TITLE
Update plaso.l2tcsv.conf

### DIFF
--- a/plaso.l2tcsv.conf
+++ b/plaso.l2tcsv.conf
@@ -83,7 +83,7 @@ output {
   if [type] == "l2tcsv" {
     elasticsearch {
       index => "logstash-l2tcsv"
-      host => localhost
+      hosts => localhost
     }
   }
 }


### PR DESCRIPTION
directive host is now obsolete and is replaced by hosts in logstash 2.2
